### PR TITLE
Added missing using statement

### DIFF
--- a/src/BootstrapSupport/ViewHelperExtensions.cs
+++ b/src/BootstrapSupport/ViewHelperExtensions.cs
@@ -5,6 +5,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Web.Mvc;
+using System.Web.Mvc.Html;
 using System.Web.Routing;
 
 namespace BootstrapSupport


### PR DESCRIPTION
I just added the missing using statement `System.Web.Mvc.Html` in ViewHelperExtensions.
