### PR TITLE
Cancel button should redirect to `Index` without submitting form

### DIFF
--- a/src/Views/Shared/Create.cshtml
+++ b/src/Views/Shared/Create.cshtml
@@ -17,7 +17,7 @@
         }
 		<div class="form-actions">
             <button type="submit" class="btn btn-primary">Save changes</button>
-            <button class="btn">Cancel</button>
+            @Html.ActionLink("Cancel",  "Index", null, new {@class = "btn "})
           </div>
     </fieldset>
 }


### PR DESCRIPTION
A button input inside a form will submit the form (at least in some
browsers it does). The most common  action for cancel will be a redirect
to `Index`, so we just create an action link to index and style it as a
button.

I'm not really sure if this is the best general scenario, but in my case it is 
at least better than form submission.
