### PR TITLE
Update src/Bootstrap/Views/Shared/_validationSummary.cshtml

### DIFF
--- a/src/Bootstrap/Views/Shared/_validationSummary.cshtml
+++ b/src/Bootstrap/Views/Shared/_validationSummary.cshtml
@@ -1,7 +1,7 @@
-@if (ViewData.ModelState[""] != null && ViewData.ModelState[""].Errors.Any()) 
+@if (ViewData.ModelState.Any(x => x.Value.Errors.Any())) 
 { 
    <div class="alert alert-error"> 
-      <a class="close" data-dismiss="alert">×</a> 
+      <a class="close" data-dismiss="alert">ï¿½</a> 
       @Html.ValidationSummary(true)
    </div>
 }


### PR DESCRIPTION
Fixed check that determines whether the validation summary is displayed. ValidationSummary uses true to include parameter validation failures but the initial if clause only looked at non-parameter validation failures.
