### PR TITLE
Use `&times;` for close button

### DIFF
--- a/src/Bootstrap/Views/Shared/_validationSummary.cshtml
+++ b/src/Bootstrap/Views/Shared/_validationSummary.cshtml
@@ -1,7 +1,7 @@
 @if (ViewData.ModelState.Any(x => x.Value.Errors.Any())) 
 { 
    <div class="alert alert-error"> 
-      <a class="close" data-dismiss="alert">&times;/a> 
+      <a class="close" data-dismiss="alert">&times;</a> 
       @Html.ValidationSummary(true)
    </div>
 }

--- a/src/Bootstrap/Views/Shared/_validationSummary.cshtml
+++ b/src/Bootstrap/Views/Shared/_validationSummary.cshtml
@@ -1,7 +1,7 @@
 @if (ViewData.ModelState.Any(x => x.Value.Errors.Any())) 
 { 
    <div class="alert alert-error"> 
-      <a class="close" data-dismiss="alert">�</a> 
+      <a class="close" data-dismiss="alert">&times;/a> 
       @Html.ValidationSummary(true)
    </div>
 }


### PR DESCRIPTION
I'm not sure about the encoding that was used; the X character renders strange on my machine. In [bootstrap docs](http://twitter.github.com/bootstrap/components.html#alerts) `&times;` is used for the close character, maybe we should too?
