### PR TITLE
Fixed nav in basic and narrow layouts

### DIFF
--- a/src/Bootstrap/BootstrapSupport/ControlGroupExtensions.cs
+++ b/src/Bootstrap/BootstrapSupport/ControlGroupExtensions.cs
@@ -1,45 +1,86 @@
 using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Web;
 using System.Web.Mvc;
 
 namespace BootstrapSupport
 {
+    public class ControlGroup : IDisposable
+    {
+        private readonly HtmlHelper _html;
+
+        public ControlGroup(HtmlHelper html){
+            _html = html;
+        }
+
+        public void Dispose(){
+            _html.EndControlGroup();
+        }
+    }
+
     public static class ControlGroupExtensions
     {
-        public static IHtmlString BeginControlGroupFor<T>(this HtmlHelper<T> html,
-                                                          Expression<Func<T, object>> modelProperty)
-        {
+        public static IHtmlString BeginControlGroupFor<T>(this HtmlHelper<T> html,Expression<Func<T, object>> modelProperty){
+            return BeginControlGroupFor(html, modelProperty, null);
+        }
+
+        public static IHtmlString BeginControlGroupFor<T>(this HtmlHelper<T> html,Expression<Func<T, object>> modelProperty,object htmlAttributes){
+            return BeginControlGroupFor(html, modelProperty,
+                                        HtmlHelper.AnonymousObjectToHtmlAttributes(htmlAttributes));
+        }
+
+        public static IHtmlString BeginControlGroupFor<T>(this HtmlHelper<T> html,Expression<Func<T, object>> modelProperty,IDictionary<string, object> htmlAttributes){
+            string propertyName = ExpressionHelper.GetExpressionText(modelProperty);
+            return BeginControlGroupFor(html, propertyName, null);
+        }
+
+        public static IHtmlString BeginControlGroupFor<T>(this HtmlHelper<T> html,string propertyName){
+            return BeginControlGroupFor(html, propertyName, null);
+        }
+
+        public static IHtmlString BeginControlGroupFor<T>(this HtmlHelper<T> html,string propertyName, object htmlAttributes){
+            return BeginControlGroupFor(html, propertyName,HtmlHelper.AnonymousObjectToHtmlAttributes(htmlAttributes));
+        }
+
+        public static IHtmlString BeginControlGroupFor<T>(this HtmlHelper<T> html,string propertyName,IDictionary<string, object> htmlAttributes){
             var controlGroupWrapper = new TagBuilder("div");
+            controlGroupWrapper.MergeAttributes(htmlAttributes);
             controlGroupWrapper.AddCssClass("control-group");
-            var partialFieldName = ExpressionHelper.GetExpressionText(modelProperty);
-            var fullHtmlFieldName = html.ViewContext.ViewData.TemplateInfo.GetFullHtmlFieldName(partialFieldName);
-            if (!html.ViewData.ModelState.IsValidField(fullHtmlFieldName))
-            {
+            string partialFieldName = propertyName;
+            string fullHtmlFieldName =
+                html.ViewContext.ViewData.TemplateInfo.GetFullHtmlFieldName(partialFieldName);
+            if (!html.ViewData.ModelState.IsValidField(fullHtmlFieldName)){
                 controlGroupWrapper.AddCssClass("error");
             }
-            var openingTag = controlGroupWrapper.ToString(TagRenderMode.StartTag);
+            string openingTag = controlGroupWrapper.ToString(TagRenderMode.StartTag);
             return MvcHtmlString.Create(openingTag);
         }
 
-        public static IHtmlString BeginControlGroupFor<T>(this HtmlHelper<T> html,
-                                                  string propertyName)
-        {
-            var controlGroupWrapper = new TagBuilder("div");
-            controlGroupWrapper.AddCssClass("control-group");
-            var partialFieldName = propertyName;
-            var fullHtmlFieldName = html.ViewContext.ViewData.TemplateInfo.GetFullHtmlFieldName(partialFieldName);
-            if (!html.ViewData.ModelState.IsValidField(fullHtmlFieldName))
-            {
-                controlGroupWrapper.AddCssClass("error");
-            }
-            var openingTag = controlGroupWrapper.ToString(TagRenderMode.StartTag);
-            return MvcHtmlString.Create(openingTag);
-        }
-
-        public static IHtmlString EndControlGroup(this HtmlHelper html)
-        {
+        public static IHtmlString EndControlGroup(this HtmlHelper html){
             return MvcHtmlString.Create("</div>");
+        }
+
+        public static ControlGroup ControlGroupFor<T>(this HtmlHelper<T> html,Expression<Func<T, object>> modelProperty){
+            return ControlGroupFor(html, modelProperty, null);
+        }
+
+        public static ControlGroup ControlGroupFor<T>(this HtmlHelper<T> html,Expression<Func<T, object>> modelProperty,object htmlAttributes){
+            string propertyName = ExpressionHelper.GetExpressionText(modelProperty);
+            return ControlGroupFor(html, propertyName,HtmlHelper.AnonymousObjectToHtmlAttributes(htmlAttributes));
+        }
+
+        public static ControlGroup ControlGroupFor<T>(this HtmlHelper<T> html, string propertyName){
+            return ControlGroupFor(html, propertyName, null);
+        }
+
+        public static ControlGroup ControlGroupFor<T>(this HtmlHelper<T> html, string propertyName,object htmlAttributes){
+            return ControlGroupFor(html, propertyName,HtmlHelper.AnonymousObjectToHtmlAttributes(htmlAttributes));
+        }
+
+        public static ControlGroup ControlGroupFor<T>(this HtmlHelper<T> html, string propertyName,IDictionary<string, object> htmlAttributes){
+            html.ViewContext.Writer.Write(BeginControlGroupFor(html, propertyName, htmlAttributes));
+            return new ControlGroup(html);
         }
     }
 
@@ -50,19 +91,8 @@ namespace BootstrapSupport
         public const string ERROR = "error";
         public const string INFORMATION = "info";
 
-        public static string[] ALL
-        {
-            get
-            {
-                return new[]
-                           {
-                               SUCCESS,
-                               ATTENTION,
-                               INFORMATION,
-                               ERROR
-                           };
-            }
+        public static string[] ALL{
+            get { return new[] {SUCCESS, ATTENTION, INFORMATION, ERROR}; }
         }
     }
-
 }

--- a/src/Bootstrap/Views/Shared/Create.cshtml
+++ b/src/Bootstrap/Views/Shared/Create.cshtml
@@ -7,17 +7,17 @@
         <legend>@Model.GetLabel() <small>Details</small></legend>
         @foreach (var property in Model.VisibleProperties())
         {
-            @Html.BeginControlGroupFor(property.Name)
+            using(Html.ControlGroupFor(property.Name)){
                 @Html.Label(property.Name.ToSeparatedWords(), new { @class = "control-label" })
-                <div class="controls">
-                    @Html.Editor(property.Name, new { @class = "input-xlarge" })
-                    @Html.ValidationMessage(property.Name, null, new { @class = "help-inline" })
-		        </div>
-            @Html.EndControlGroup()
+                 <div class="controls">
+                     @Html.Editor(property.Name, new { @class = "input-xlarge" })
+                     @Html.ValidationMessage(property.Name, null, new { @class = "help-inline" })
+                 </div>
+            }
         }
 		<div class="form-actions">
             <button type="submit" class="btn btn-primary">Save changes</button>
-            @Html.ActionLink("Cancel",  "Index", null, new {@class = "btn "})
+            @Html.ActionLink("Cancel", "Index", null, new { @class = "btn " })
           </div>
     </fieldset>
 }

--- a/src/Bootstrap/Views/Shared/_BootstrapLayout.basic.cshtml
+++ b/src/Bootstrap/Views/Shared/_BootstrapLayout.basic.cshtml
@@ -22,7 +22,7 @@
                         <span class="icon-bar"></span>
                     </a>
                     <a class="brand" href="#" title="change in _bootstrapLayout.basic.cshtml">Application Name</a>
-                    <div class="nav-collapse">
+                    <div class="nav-collapse collapse">
                         <ul class="nav">
                             @Html.Navigation()
                         </ul>

--- a/src/Bootstrap/Views/Shared/_BootstrapLayout.narrow.cshtml
+++ b/src/Bootstrap/Views/Shared/_BootstrapLayout.narrow.cshtml
@@ -48,7 +48,6 @@
       /* added to trim our long nav menu to a more appropriate appearance */
       .masthead .nav {
           max-width: 416px;
-          overflow-y: hidden;
           height: 3em;
       }
     </style>


### PR DESCRIPTION
Hi Eric. You are on to a good thing here. This has saved me a few hours. Thank you for your work on this. I have fixed up some little issues.

In the basic layout the nav-collapse div needed an extra collapse class to allow the dropdown items to be visible in the collapsed state.

![Basic Collapsed Nav bug](https://f.cloud.github.com/assets/929529/70621/e8768edc-5fb5-11e2-9b77-48c4fae984a2.png)

In the narrow layout the y-overflow on .masthead .nav stopped the dropdown from displaying.

![Narrow Nav Bug](https://f.cloud.github.com/assets/929529/70622/e8c97e9e-5fb5-11e2-83eb-0bc119c64bba.png)
