### PR TITLE
Fixing invalid JSON when parsing empty attributes

### DIFF
--- a/src/Bootstrap/Scripts/jquery.validate.unobtrusive-custom-for-bootstrap.js
+++ b/src/Bootstrap/Scripts/jquery.validate.unobtrusive-custom-for-bootstrap.js
@@ -40,7 +40,7 @@
 
     function onError(error, inputElement) {  // 'this' is the form element
         var container = $(this).find("[data-valmsg-for='" + escapeAttributeValue(inputElement[0].name) + "']"),
-            replace = $.parseJSON(container.attr("data-valmsg-replace")) !== false;
+            replace = $.parseJSON(container.attr("data-valmsg-replace") || "null") !== false;
 
         container.removeClass("field-validation-valid").addClass("field-validation-error");
         container.closest(".control-group").addClass("error");
@@ -71,7 +71,7 @@
 
     function onSuccess(error) {  // 'this' is the form element
         var container = error.data("unobtrusiveContainer"),
-            replace = $.parseJSON(container.attr("data-valmsg-replace"));
+            replace = $.parseJSON(container.attr("data-valmsg-replace") || "null");
 
         if (container) {
             container.addClass("field-validation-valid").removeClass("field-validation-error");


### PR DESCRIPTION
Hey Eric,
I noticed that using the latest jQuery, the parsing throws an exception for empty attributes. Here is a fix. Thanks!

An empty string (or null object) is invalid JSON, and needs to be
converted to a 'null' string. jQuery 1.9.0 has exposed this previously
accepted JSON. Now we need to convert it.

http://forum.jquery.com/topic/parsejson-in-1-9-0-is-different-from-earlier-versions
Currently, if using jQuery 1.9.0, this code will throw an exception when
dealing with empty validation attributes.
