### PR TITLE
Solved Issue for Win8/IE10/jQuery 1.9.0/VS2012

### DIFF
--- a/src/Bootstrap/App_Start/BootstrapBundleConfig.cs
+++ b/src/Bootstrap/App_Start/BootstrapBundleConfig.cs
@@ -9,7 +9,8 @@ namespace BootstrapSupport
         public static void RegisterBundles(BundleCollection bundles)
         {
             bundles.Add(new ScriptBundle("~/js").Include(
-                "~/Scripts/jquery-1.*",
+                "~/Scripts/jquery-{version}.js",
+                "~/Scripts/jquery-migrate-{version}.js",
                 "~/Scripts/bootstrap.js",
                 "~/Scripts/jquery.validate.js",
                 "~/scripts/jquery.validate.unobtrusive.js",

--- a/src/twitter-bootstrap-mvc.nuspec
+++ b/src/twitter-bootstrap-mvc.nuspec
@@ -17,6 +17,7 @@
       	<dependency id="navigationroutes.mvc4" />
 	      <dependency id="microsoft.aspnet.web.optimization" version="1.0.0"/>
       	<dependency id="jquery" />
+      	<dependency id="jquery.migrate" />
       	<dependency id="Microsoft.jQuery.Unobtrusive.Ajax" />
       	<dependency id="Microsoft.jQuery.Unobtrusive.Validation" />
     </dependencies> 


### PR DESCRIPTION
Addressed an issue where the jQuery source map file on IE10, running on Win 8 with Visual Studio 2012, was causing an issue in the minification/client script delivery pipe, resulting in critical JavaScript errors being thrown from the browser.

The fix was two-fold.  First, I switched the jQuery bundle to use the semantic version tag. Second, I added jQuery.Migrate to the package dependencies and added it to the bundle config.

Details on the error here: http://jameschambers.com/2013/01/jquery-script-map-causing-critical-error-in-jquery-1-9-0/

...and here: http://jameschambers.com/2013/01/upgrading-to-jquery-1-9-0-starts-giving-you-unhandled-exception-errors/
