### PR TITLE
Navigation Extension Tests

### DIFF
--- a/src/NavigationRoutes/UnitTests/Navigation_Extensions_Should.cs
+++ b/src/NavigationRoutes/UnitTests/Navigation_Extensions_Should.cs
@@ -1,0 +1,41 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Web.Mvc;
+using NavigationRoutes;
+using System.Web.Routing;
+using Should;
+
+namespace UnitTests
+{
+    [TestFixture]
+    public class Navigation_Extensions_Should: RouteTesterBase
+    {
+        [Test]
+        public void produce_a_proper_url_for_home_index()
+        {            
+            var routes = new RouteCollection();
+            routes.MapNavigationRoute<HomeController>("Home", c => c.Index());
+            var helper = new HtmlHelper(new TestViewContext(), new TestViewDataContainer(), routes);
+
+            var result = helper.NavigationListItemRouteLink(routes["Navigation-Home-Index"] as NamedRoute).ToString();
+
+            result.ShouldContain("href=\"/\"");
+        }
+
+        [Test]
+        public void produce_a_proper_url_for_home_about()
+        {
+            var routes = new RouteCollection();
+            routes.MapNavigationRoute<HomeController>("Home", c => c.Index());
+            routes.MapNavigationRoute<HomeController>("Home", c => c.About());
+            var helper = new HtmlHelper(new TestViewContext(), new TestViewDataContainer(), routes);
+
+            var result = helper.NavigationListItemRouteLink(routes["Navigation-Home-About"] as NamedRoute).ToString();
+
+            result.ShouldContain("href=\"/home/about\"");
+        }
+    }
+}

--- a/src/NavigationRoutes/UnitTests/TestDoubles/TestHttpContext.cs
+++ b/src/NavigationRoutes/UnitTests/TestDoubles/TestHttpContext.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Web;
+
+namespace UnitTests
+{
+    public class TestHttpContext : HttpContextBase
+    {
+        HttpRequestBase _httpRequest = new TestHttpRequest();
+        HttpResponseBase _httpResponse = new TestHttpResponse();
+
+        public override HttpRequestBase Request
+        {
+            get
+            {
+                return _httpRequest;
+            }
+        }
+
+        public override HttpResponseBase Response
+        {
+            get
+            {
+                return _httpResponse;
+            }
+        }
+    }
+}

--- a/src/NavigationRoutes/UnitTests/TestDoubles/TestHttpRequest.cs
+++ b/src/NavigationRoutes/UnitTests/TestDoubles/TestHttpRequest.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Text;
+using System.Web;
+
+namespace UnitTests
+{
+    public class TestHttpRequest : HttpRequestBase
+    {
+        NameValueCollection _serverVariables = new NameValueCollection();
+
+        public override string ApplicationPath
+        {
+            get
+            {
+                return "";
+            }
+        }
+
+        public override NameValueCollection ServerVariables
+        {
+            get
+            {
+                return _serverVariables;
+            }
+        }
+    }
+}

--- a/src/NavigationRoutes/UnitTests/TestDoubles/TestHttpResponse.cs
+++ b/src/NavigationRoutes/UnitTests/TestDoubles/TestHttpResponse.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Web;
+
+namespace UnitTests
+{
+    public class TestHttpResponse : HttpResponseBase
+    {
+        public override string ApplyAppPathModifier(string virtualPath)
+        {
+            return virtualPath;
+        }
+    }
+}

--- a/src/NavigationRoutes/UnitTests/TestDoubles/TestViewContext.cs
+++ b/src/NavigationRoutes/UnitTests/TestDoubles/TestViewContext.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Web;
+using System.Web.Mvc;
+
+namespace UnitTests
+{
+    public class TestViewContext: ViewContext
+    {
+        HttpContextBase _httpContext = new TestHttpContext();
+
+        public override HttpContextBase HttpContext
+        {
+            get
+            {
+                return _httpContext;
+            }
+            set
+            {
+                _httpContext = value;
+            }
+        }
+    }
+}

--- a/src/NavigationRoutes/UnitTests/TestDoubles/TestViewDataContainer.cs
+++ b/src/NavigationRoutes/UnitTests/TestDoubles/TestViewDataContainer.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Web.Mvc;
+
+namespace UnitTests
+{
+    public class TestViewDataContainer : IViewDataContainer
+    {
+        private ViewDataDictionary _viewData = new ViewDataDictionary();
+        public ViewDataDictionary ViewData { get { return _viewData; } set { _viewData = value; } }
+    }
+}

--- a/src/NavigationRoutes/UnitTests/UnitTests.csproj
+++ b/src/NavigationRoutes/UnitTests/UnitTests.csproj
@@ -74,12 +74,18 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Navigation_Extensions_Should.cs" />
     <Compile Include="Navigation_Route_Should.cs" />
     <Compile Include="NullFilter.cs" />
     <Compile Include="RemoveAuthorizeActions.cs" />
     <Compile Include="RouteTesterBase.cs" />
     <Compile Include="TestDoubles\HomeController.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestDoubles\TestHttpContext.cs" />
+    <Compile Include="TestDoubles\TestHttpRequest.cs" />
+    <Compile Include="TestDoubles\TestHttpResponse.cs" />
+    <Compile Include="TestDoubles\TestViewContext.cs" />
+    <Compile Include="TestDoubles\TestViewDataContainer.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
I might be missing something, but when the navigation extensions write out a link for a non-default action of the current controller, the URL isn't correct. 

For example, the Url for the Index action of Home is ok ("/"), but for About the link comes out as /about instead of /home/about. 

I added a failing test to the project, if this helps.

If I am misunderstanding how to use the navigation extensions, please disregard :)
