### PR TITLE
Navigation Overhaul

### DIFF
--- a/src/Bootstrap/App_Start/ExampleLayoutsRouteConfig.cs
+++ b/src/Bootstrap/App_Start/ExampleLayoutsRouteConfig.cs
@@ -5,6 +5,7 @@ using System.Web;
 using System.Web.Mvc;
 using System.Web.Routing;
 using BootstrapMvcSample.Controllers;
+using NavigationRouteFilterExamples;
 using NavigationRoutes;
 
 namespace BootstrapMvcSample
@@ -13,11 +14,21 @@ namespace BootstrapMvcSample
     {
         public static void RegisterRoutes(RouteCollection routes)
         {
-            routes.MapNavigationRoute<HomeController>("Automatic Scaffolding", c => c.Index(), "", true);
+            // this enables menu suppression for routes with a FilterToken of "admin" set
+            NavigationRouteFilters.Filters.Add(new AdministrationRouteFilter());
+
+            routes.MapNavigationRoute<HomeController>("Automatic Scaffolding", c => c.Index(), "",
+                                                      new NavigationRouteOptions {HasBreakAfter = true});
+
+            // this route will only show if users are in the role specified in the AdministrationRouteFilter
+            // by default, when you run the site, you will not see this. Explore the AdministrationRouteFilter
+            // class for more information.
+            routes.MapNavigationRoute<HomeController>("Administration Menu", c => c.Admin(), "",
+                                                      new NavigationRouteOptions { HasBreakAfter = true, FilterToken = "admin"});
 
             routes.MapNavigationRoute<ExampleLayoutsController>("Example Layouts", c => c.Starter())
                   .AddChildRoute<ExampleLayoutsController>("Marketing", c => c.Marketing())
-                  .AddChildRoute<ExampleLayoutsController>("Fluid", c => c.Fluid(), "", true)
+                  .AddChildRoute<ExampleLayoutsController>("Fluid", c => c.Fluid(), new NavigationRouteOptions{ HasBreakAfter = true})
                   .AddChildRoute<ExampleLayoutsController>("Sign In", c => c.SignIn())
                 ;
         }

--- a/src/Bootstrap/Controllers/HomeController.cs
+++ b/src/Bootstrap/Controllers/HomeController.cs
@@ -71,5 +71,11 @@ namespace BootstrapMvcSample.Controllers
             return View(model);
         }
 
+
+        internal ActionResult Admin()
+        {
+            // used for demonstrationg route filters
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Bootstrap/NavigationRouteFilterExamples/AdministrationRouteFilter.cs
+++ b/src/Bootstrap/NavigationRouteFilterExamples/AdministrationRouteFilter.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using NavigationRoutes;
+
+namespace NavigationRouteFilterExamples
+{
+    public class AdministrationRouteFilter :INavigationRouteFilter
+    {
+        // an excercise for the reader would be to load the role name 
+        // from your config file so this isn't compiled in, or add a constructor
+        // that accepts a role name to use to make this a more generic filter
+        private string AdministrationRole = "admin";
+
+        public bool ShouldRemove(System.Web.Routing.Route navigationRoutes)
+        {
+            if (navigationRoutes.DataTokens.HasFilterToken())
+            {
+                var filterToken = navigationRoutes.DataTokens.FilterToken();
+                var result = !HttpContext.Current.User.IsInRole(AdministrationRole) && filterToken == AdministrationRole;
+                return result;
+            }
+
+            return false;
+
+        }
+    }
+}

--- a/src/Bootstrap/Views/Shared/_BootstrapLayout.basic.cshtml
+++ b/src/Bootstrap/Views/Shared/_BootstrapLayout.basic.cshtml
@@ -23,9 +23,7 @@
                     </a>
                     <a class="brand" href="#" title="change in _bootstrapLayout.basic.cshtml">Application Name</a>
                     <div class="nav-collapse collapse">
-                        <ul class="nav">
-                            @Html.Navigation()
-                        </ul>
+                          @Html.Navigation()
                     </div>
                 </div>
             </div>

--- a/src/NavigationRoutes/NavigationRoutes/NamedRoute.cs
+++ b/src/NavigationRoutes/NavigationRoutes/NamedRoute.cs
@@ -6,9 +6,11 @@ namespace NavigationRoutes
 {
     public class NamedRoute : Route
     {
-         string _name;
-         string _displayName;
-         List<NamedRoute> _childRoutes = new List<NamedRoute>();
+        string _name = string.Empty;
+        string _displayName = string.Empty;
+        string _navigationRoute = string.Empty;
+
+        List<NamedRoute> _childRoutes = new List<NamedRoute>();
 
         public NamedRoute(string name, string url, IRouteHandler routeHandler)
             : base(url, routeHandler)
@@ -55,8 +57,26 @@ namespace NavigationRoutes
             get { return _displayName ?? _name; }
             set { _displayName = value; }
         }
+        
         public List<NamedRoute> Children { get { return _childRoutes; } }
         public bool IsChild { get; set; }
-        public bool ShouldBreakAfter { get; set; }    
+        
+        /// <summary>
+        /// The ID to be rendered for the UL containing the navigation items. Ignored on child routes.
+        /// If set, each distinct ID will be rendered as a seperate UL.
+        /// </summary>
+        public string NavigationGroup
+        {
+            get { return _navigationRoute; }
+            set { _navigationRoute = value.Replace(" ", "-"); }
+        }
+        
+        /// <summary>
+        /// Optional settings to control the rendering behavior of the navigation route in the menu.
+        /// </summary>
+        public NavigationRouteOptions Options { get; set; }
+
+
+
     }
 }

--- a/src/NavigationRoutes/NavigationRoutes/NavigationRouteConfigurationExtensions.cs
+++ b/src/NavigationRoutes/NavigationRoutes/NavigationRouteConfigurationExtensions.cs
@@ -47,29 +47,30 @@ namespace NavigationRoutes
         }
 
 
-        public static NavigationRouteBuilder MapNavigationRoute<T>(this RouteCollection routes, string displayName, Expression<Func<T, ActionResult>> action, string areaName="", bool breakAfter = false) where T : IController
+        public static NavigationRouteBuilder MapNavigationRoute<T>(this RouteCollection routes, string displayName, Expression<Func<T, ActionResult>> action, string navigationGroup = "", NavigationRouteOptions options = null) where T : IController
         {
             var newRoute = new NamedRoute("", "", new MvcRouteHandler());
-            newRoute.ToDefaultAction(action,areaName);
             newRoute.DisplayName = displayName;
-            newRoute.ShouldBreakAfter = breakAfter;
+            newRoute.NavigationGroup = navigationGroup;
+            newRoute.Options = options ?? new NavigationRouteOptions();
+            newRoute.ToDefaultAction(action, newRoute.Options);
             routes.Add(newRoute.Name, newRoute);
             return new NavigationRouteBuilder(routes, newRoute);
         }
 
-        public static NavigationRouteBuilder AddChildRoute<T>(this NavigationRouteBuilder builder, string DisplayText, Expression<Func<T, ActionResult>> action, string areaName="", bool breakAfter = false) where T : IController
+        public static NavigationRouteBuilder AddChildRoute<T>(this NavigationRouteBuilder builder, string DisplayText, Expression<Func<T, ActionResult>> action, NavigationRouteOptions options = null) where T : IController
         {
             var childRoute = new NamedRoute("", "", new MvcRouteHandler());
-            childRoute.ToDefaultAction<T>(action,areaName);
             childRoute.DisplayName = DisplayText;
             childRoute.IsChild = true;
-            childRoute.ShouldBreakAfter = breakAfter;
+            childRoute.Options = options ?? new NavigationRouteOptions();
+            childRoute.ToDefaultAction<T>(action, childRoute.Options);
             builder._parent.Children.Add(childRoute);
             builder._routes.Add(childRoute.Name,childRoute);
             return builder;
         }
 
-        public static NamedRoute ToDefaultAction<T>(this NamedRoute route, Expression<Func<T, ActionResult>> action,string areaName) where T : IController
+        public static NamedRoute ToDefaultAction<T>(this NamedRoute route, Expression<Func<T, ActionResult>> action, NavigationRouteOptions options) where T : IController
         {
             var body = action.Body as MethodCallExpression;
 
@@ -108,6 +109,8 @@ namespace NavigationRoutes
             route.Defaults.Add("controller", controllerName);
             route.Defaults.Add("action", actionName);
 
+            var areaName = options.AreaName;
+
             route.Url= CreateUrl(actionName,controllerName,areaName);
             //TODO: Add area to route name
             if(areaName=="")
@@ -118,9 +121,14 @@ namespace NavigationRoutes
             if(route.DataTokens == null)
                 route.DataTokens = new RouteValueDictionary();
             route.DataTokens.Add("Namespaces", new string[] {typeof (T).Namespace});
+
             if (!string.IsNullOrEmpty(areaName))
             {
                 route.DataTokens.Add("area", areaName.ToLower());
+            }
+            if (!string.IsNullOrEmpty(options.FilterToken))
+            {
+                route.DataTokens.Add(Defaults.FILTER_TOKEN_KEY, options.FilterToken.ToLower());
             }
 
             return route;

--- a/src/NavigationRoutes/NavigationRoutes/NavigationRouteOptions.cs
+++ b/src/NavigationRoutes/NavigationRoutes/NavigationRouteOptions.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace NavigationRoutes
+{
+    public class NavigationRouteOptions
+    {
+        public NavigationRouteOptions()
+        {
+            this.AreaName = string.Empty;
+            this.HasBreakAfter = false;
+            this.IsRightAligned = false;
+            this.FilterToken = string.Empty;
+            this.ElementId = string.Empty;
+        }
+
+        /// <summary>
+        /// You can specify an area to properly render your route, if required
+        /// </summary>
+        public string AreaName { get; set; }
+
+        /// <summary>
+        /// This will be the ID rendered in the DOM, if specified
+        /// </summary>
+        public string ElementId { get; set; }
+
+        /// <summary>
+        /// This will insert a break after the menu item rendered for the route. If this is a top-level
+        /// item, the break will be in the nav bar. For child items, the break appears in the dropdown list.
+        /// </summary>
+        public bool HasBreakAfter { get; set; }
+
+        /// <summary>
+        /// Setting this property on any item will cause the UL containing the entire group to be
+        /// pulled to right.
+        /// </summary>
+        public bool IsRightAligned { get; set; }
+
+        /// <summary>
+        /// A string value to store additional information about the route for the purposes of
+        /// filtering. The value is stored in the DataTokens collection and can be accessed in
+        /// an implementation of INavigationRouteFilter.
+        /// </summary>
+        public string FilterToken { get; set; }
+
+        // todo: figure out other relevant options
+        // ? public bool HasBreakBefore { get; set; }
+        // ? public string Icon { get; set; }
+        
+    }
+}

--- a/src/NavigationRoutes/NavigationRoutes/NavigationRoutes.csproj
+++ b/src/NavigationRoutes/NavigationRoutes/NavigationRoutes.csproj
@@ -76,6 +76,7 @@
     <Compile Include="NavigationExtensions.cs" />
     <Compile Include="NavigationRouteConfigurationExtensions.cs" />
     <Compile Include="NavigationRouteFilter.cs" />
+    <Compile Include="NavigationRouteOptions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NavigationRoutes/UnitTests/Navigation_Route_Should.cs
+++ b/src/NavigationRoutes/UnitTests/Navigation_Route_Should.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using Should;
@@ -19,8 +20,8 @@ namespace UnitTests
         {
             var routes = new System.Web.Routing.RouteCollection();
 
-            routes.MapNavigationRoute<HomeController>("Home", c => c.Index(),"Admin");
-            routes.MapNavigationRoute<HomeController>("About", c => c.About(),"AdMin");
+            routes.MapNavigationRoute<HomeController>("Home", c => c.Index(), "", new NavigationRouteOptions{ AreaName = "Admin"});
+            routes.MapNavigationRoute<HomeController>("About", c => c.About(), "", new NavigationRouteOptions { AreaName = "AdMin" });
 
             routes.Count.ShouldNotEqual(0);
 
@@ -67,7 +68,7 @@ namespace UnitTests
         {
             var routes = RouteTable.Routes;
             var filter = new NullFilter();
-            NavigationRoutes.NavigationRoutes.Filters.Add(filter);
+            NavigationRoutes.NavigationRouteFilters.Filters.Add(filter);
             routes.MapNavigationRoute<HomeController>("Home", c => c.Index());
 
             NavigationRoutes.NavigationViewExtensions.Navigation(null);
@@ -123,6 +124,19 @@ namespace UnitTests
             routes.Count().ShouldEqual(1);
             var namespaces = (string[]) ((NamedRoute) routes["Navigation-Home-Index"]).DataTokens["Namespaces"];
             namespaces.ShouldContain("UnitTests");
+        }
+
+        [Test]
+        public void add_filter_tokens()
+        {
+            var filterTokenText = "foo";
+            var routes = new System.Web.Routing.RouteCollection();
+            routes.MapNavigationRoute<HomeController>("Home", c => c.Index(), "", new NavigationRouteOptions { FilterToken = filterTokenText });
+
+            Assert.IsTrue(((NamedRoute)routes["Navigation-Home-Index"]).DataTokens.HasFilterToken());
+
+            var filterToken = (string)((NamedRoute)routes["Navigation-Home-Index"]).DataTokens.FilterToken();
+            filterToken.ShouldEqual(filterTokenText);
         }
     }
 }

--- a/src/twitter-bootstrap-mvc-sample.nuspec
+++ b/src/twitter-bootstrap-mvc-sample.nuspec
@@ -16,6 +16,7 @@
   <files>
     <file src="Bootstrap\Controllers\Home*.cs" target="Content\Controllers"></file>
     <file src="Bootstrap\Controllers\Example*.cs" target="Content\Controllers"></file>
+    <file src="Bootstrap\NavigationRouteFilterExamples\*.*" target="Content\NavigationRouteFilterExamples"></file>
     <file src="Bootstrap\Models\*.*" target="Content\Models"></file>
     <file src="Bootstrap\Views\ExampleLayouts\*.*" target="Content\Views\ExampleLayouts"></file>
   </files>


### PR DESCRIPTION
Built in support for the concept of "NavigationRouteOptions" to clean up
the code smell of "ShouldBreakAfter". Refactored the navigation list
builder to support groups. Added support for "pull-right" on menu group
ULs. Moved area information into the NavigationRouteOptions class.
Updated and added tests as necessary. Updated samples, added comments
and example route filter to sample project.
