### PR TITLE
Added style to hide initial validation summary

### DIFF
--- a/src/Bootstrap/Content/bootstrap-mvc-validation.css
+++ b/src/Bootstrap/Content/bootstrap-mvc-validation.css
@@ -2,3 +2,8 @@
 {
     list-style-type: none;
 }
+
+.validation-summary-valid
+{
+    display: none;
+}

--- a/src/Bootstrap/Content/bootstrap-mvc-validation.css
+++ b/src/Bootstrap/Content/bootstrap-mvc-validation.css
@@ -3,7 +3,36 @@
     list-style-type: none;
 }
 
+.field-validation-error
+{
+    color: #e80c4d;
+    font-weight: bold;
+}
+
+.field-validation-valid
+{
+    display: none;
+}
+
+input.input-validation-error
+{
+    border: 1px solid #e80c4d;
+}
+
+input[type="checkbox"].input-validation-error
+{
+    border: 0 none;
+}
+
+.validation-summary-errors
+{
+    color: #e80c4d;
+    font-weight: bold;
+    font-size: 1.1em;
+}
+
 .validation-summary-valid
 {
     display: none;
 }
+


### PR DESCRIPTION
When a validation summary has the message property set, e.g. @Html.ValidationSummary( "Please complete all required fields before submitting" ) - the message is displayed on the initial page load even though validation has not yet failed.

Adding this style will prevent the message from being displayed until the validation fails.
