### PR TITLE
Scripts folder reference normalization

### DIFF
--- a/src/Bootstrap/App_Start/BootstrapBundleConfig.cs
+++ b/src/Bootstrap/App_Start/BootstrapBundleConfig.cs
@@ -13,7 +13,7 @@ namespace BootstrapSupport
                 "~/Scripts/jquery-migrate-{version}.js",
                 "~/Scripts/bootstrap.js",
                 "~/Scripts/jquery.validate.js",
-                "~/scripts/jquery.validate.unobtrusive.js",
+                "~/Scripts/jquery.validate.unobtrusive.js",
                 "~/Scripts/jquery.validate.unobtrusive-custom-for-bootstrap.js"
                 ));
 


### PR DESCRIPTION
Fix the Scripts folder path so it's standarized and doesn't get included
twice when used in MVC 4 project with a Bundle.
